### PR TITLE
fixes for v3 cam

### DIFF
--- a/config.js
+++ b/config.js
@@ -18,7 +18,10 @@ export const systemConfig = {
 
   // How often to output stats (in seconds)
   // Set 0 to disable
-  STATS_PERIOD_SEC: 30
+  STATS_PERIOD_SEC: 30,
+
+  // Full path to ffmpeg. If you want to use the copy that is in your path simply set this to 'ffmpeg'.
+  FFMPEG_PATH: 'ffmpeg'
 }
 
 // This is default settings for each camera

--- a/methods/checkNewVideoFile.js
+++ b/methods/checkNewVideoFile.js
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process'
 import { promises as fs } from 'fs'
+import { systemConfig } from '../config'
 
 import log from './log'
 
@@ -9,13 +10,14 @@ const FRESH_FILE_THRESHOLD_SEC = 10
 
 const convertFile = async (camera, filepath, startNumber) => {
   const logPrefix = `${camera.logPrefix}[convertFile]`
-  const cmd = 'ffmpeg'
+  const cmd = systemConfig.FFMPEG_PATH || 'ffmpeg'
   const args = [
     '-i', filepath,
-    '-vcodec', 'copy',
-    '-c', 'copy',
+    '-c:v', 'copy',
+    '-c:a', 'aac',
     '-hls_allow_cache', '0',
     '-hls_list_size', '0',
+    '-force_key_frames', `expr:"gte(t,n_forced*2)"`,
     '-hls_time', '2',
     '-start_number', startNumber,
     '-hls_flags', 'delete_segments+omit_endlist',

--- a/methods/createHttpHandler.js
+++ b/methods/createHttpHandler.js
@@ -42,18 +42,21 @@ export const createHttpHandler = (camerasInstances) => {
         const currentSegments = []
         for (const segNum in cameraInstance.state.segments) {
           const seg = cameraInstance.state.segments[segNum]
+          
+          if (segNum > systemConfig.MAX_SEGMENTS_IN_PLAYLIST - 1) {
+            break
+          }
+
+          if (segNum == 0 || cameraInstance.state.segments[segNum - 1].duration < 2) currentSegments.push(`#EXT-X-DISCONTINUITY`)
           currentSegments.push(`#EXTINF:${seg.duration},`)
           currentSegments.push(`/${cameraName}/${seg.filename}`)
           log('debug2', logPrefix, `[${cameraName}][${cameraInstance.state.mediaSequenceCounter}] ${seg.filename}`)
-
-          if ((segNum + 1) >= systemConfig.MAX_SEGMENTS_IN_PLAYLIST) {
-            break
-          }
         }
 
         const plsBody = [
           '#EXTM3U',
           '#EXT-X-VERSION:3',
+          '#EXT-X-ALLOW-CACHE:NO',
           '#EXT-X-TARGETDURATION:2',
           `#EXT-X-MEDIA-SEQUENCE:${cameraInstance.state.mediaSequenceCounter}`,
           currentSegments.join('\n')


### PR DESCRIPTION
I got a Wyze Cam V3 and tried this project but it would only stream until it reached the end of the minute. I tested in VLC, Chrome, Shinobi and iOS and the only one that would stream past one minute was iOS. I don't know if this is something unique to the V3 or if this is an issue with the older cam too. The fix involved a few things. First I noticed the first segment was always 4 secs even though the ffmpeg command line was requesting 2 secs. After some research I discovered this has to do with B frames. The fix for this was to add this option:
```
'-force_key_frames expr:"gte(t,n_forced*2)"
```

The next issue was the last segment of the minute was very short and the playSegment function would eat it up so fast it cycled out of the playlist before the video player did a playlist refresh. This would cause playback to end. This took two changes to resolve. First was to add "#EXT-X-DISCONTINUITY" just after a short segment. The other issue was MAX_SEGMENTS_IN_PLAYLIST wasn't being handled properly so the playlist only had 2 segments even though the config calls for 3 segments. BTW, play back for me only works if this is set to 3 or higher.

While I was working on the project I added a new config option where you can specify the full path to ffmpeg incase you don't have it pathed or simply want to use a custom version overriding the one in your path. I also added transcoding for the audio to aac because the original audio wouldn't play correctly.

These changes fixed playback in VLC and Chrome but the Docker version of Shinobi running on Debian Buster was still hanging. The fix was to update ffmpeg from 4.1.6 (latest in the stable buster repo) to 4.3.2. Now it's running solid in Shinobi.

I only have a V3 camera so I can't test to make sure I didn't break playback on a V2. Maybe someone can confirm this before merging. I don't foresee any of these changes negatively impacting the V2 though.