### PR TITLE
Switch Path dependency for cross-platform paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 .DS_Store
 package-lock.json
+tmp/

--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-import path from 'path'
+import path from 'path-extra'
 
 export const systemConfig = {
   // How detailed would you like to have logs in console (from 0 to 3)

--- a/methods/createHttpHandler.js
+++ b/methods/createHttpHandler.js
@@ -61,6 +61,7 @@ export const createHttpHandler = (camerasInstances) => {
 
         res.statusCode = 200
         res.setHeader('Content-Type', 'application/x-mpegURL')
+        res.setHeader('Cache-Control', 'no-cache')
         res.end(plsBody.join('\n'))
         return
       }

--- a/package.json
+++ b/package.json
@@ -20,15 +20,19 @@
     "esm": "^3.2.25"
   },
   "keywords": [
-    "wyzecam", 
-    "wyze", 
-    "HLS", 
-    "RTSP", 
-    "NFS", 
-    "ffmpeg", 
+    "wyzecam",
+    "wyze",
+    "HLS",
+    "RTSP",
+    "NFS",
+    "ffmpeg",
     "CCTV",
     "NVR",
     "Shinobi",
     "motioneye"
-  ]
+  ],
+  "dependencies": {
+    "path-extra": "^4.3.0",
+    "pm2": "^5.1.2"
+  }
 }


### PR DESCRIPTION
Added a dependency on Path-Extra to allow for cross-platform file paths. Have verified that this runs on Windows 11 with NodeJS v14.16.0. Also added an HTTP header to prevent client-side caching of the hls.m3u8 file, primarily to try to address issues with the Home Assistant front end.